### PR TITLE
Fix bug in AIV reports for usernames containing equals sign

### DIFF
--- a/afreporter.py
+++ b/afreporter.py
@@ -460,7 +460,7 @@ def reportUser(targetUser: user.User, trippedFilter=None):
     if targetUser.isIP:
         reportLine = "\n* {{IPvandal|%s}} - " % targetUsername
     else:
-        reportLine = "\n* {{Vandal|%s}} - " % targetUsername
+        reportLine = "\n* {{Vandal|1=%s}} - " % targetUsername
 
     editSummary = "Reporting [[Special:Contributions/%s]]" % targetUsername
     if trippedFilter is None:


### PR DESCRIPTION
See lower entry at https://w.wiki/59Jz. Caused by the username `==imapatata`. This can be solved by wrapping the usernames in `{{vandal|1=%s}}` rather than `{{vandal|%s}}`.